### PR TITLE
feat(testing): Implement Playwright code coverage pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ dist
 dist-ssr
 *.local
 
+# Coverage files
+coverage/
+.nyc_output/
+playwright-coverage/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,16 @@
+{
+  "all": true,
+  "check-coverage": false,
+  "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.js"],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "tests/**/*",
+    "**/*.d.ts",
+    "node_modules/**"
+  ],
+  "reporter": ["html", "text", "lcov"],
+  "extension": [".js", ".ts", ".vue"],
+  "report-dir": "./coverage",
+  "temp-dir": "./.nyc_output"
+}

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,91 @@
+# Playwright Coverage Setup Journey - Complete Summary
+
+Great work on successfully setting up coverage reporting for your Playwright tests! Let's summarize the journey we've taken together to get your Vue/Vite application's test coverage working.
+What We've Accomplished
+
+Identified the Challenge: We started with your need to set up code coverage for Playwright tests similar to Jest coverage reports for unit tests.
+Worked Through Configuration Issues:
+
+Created an initial configuration that needed TypeScript modifications
+Discovered and fixed issues with the server port (changed from 3000 to 5173)
+Used TypeScript assertions to work around type definition limitations
+
+Solved Connection Issues:
+
+Identified that your development server was running on port 5173 instead of the expected 3000
+Updated the webServer configuration to point to the correct port
+
+Created an Explicit Coverage Test:
+
+Built a dedicated test file at /Users/shantirai/Desktop/PROJECTS/avatarGenImg/tests/explicit-coverage.spec.ts
+Used the page.coverage API to explicitly collect JavaScript coverage
+Added code to save coverage data to the playwright-coverage directory
+
+Fixed URL Assertion Issues:
+
+Modified the test to correctly expect your application's actual URL
+Successfully ran the test which generated coverage data
+
+The Final Working Setup
+You now have:
+
+Configuration File:
+
+/Users/shantirai/Desktop/PROJECTS/avatarGenImg/playwright.config.ts with:
+
+Correct webServer port (5173)
+TypeScript-friendly coverage configuration
+
+Coverage Test File:
+
+/Users/shantirai/Desktop/PROJECTS/avatarGenImg/tests/explicit-coverage.spec.ts
+Successfully collects and saves coverage data
+
+Coverage Output:
+
+/Users/shantirai/Desktop/PROJECTS/avatarGenImg/playwright-coverage/coverage-data.json
+Raw coverage data that can be transformed into readable reports
+
+Next Steps
+Now that you have coverage collection working, here's what you can do next:
+
+Generate Human-Readable Reports:
+bashCopy# Install NYC for report visualization
+npm install -D nyc
+
+# Add to package.json
+
+# "scripts": {
+
+# "coverage-report": "nyc report --reporter=html --reporter=text --temp-dir=./playwright-coverage"
+
+# }
+
+# Generate HTML report
+
+npm run coverage-report
+
+View Your Coverage Report:
+
+Open /Users/shantirai/Desktop/PROJECTS/avatarGenImg/coverage/index.html in your browser
+This will show you a color-coded view of which lines are covered by your tests
+
+Integrate With Your Regular Tests:
+
+Apply the coverage collection technique to your main test files
+Or run all tests with coverage enabled
+
+Improve Coverage:
+
+Identify areas with low coverage in your report
+Add tests for uncovered functionality
+
+Documentation Resources
+For your continued learning and reference:
+
+Playwright Coverage API Documentation - Details on the Coverage API methods
+Istanbul Coverage Report Guide - Options for customizing your coverage reports
+Vite + Vue Testing Best Practices - Official Vue testing guidance
+GitHub Example: Playwright Coverage for Vue - Official examples for reference
+
+You've successfully set up Playwright coverage reporting for your Vue/Vite application! Is there any specific aspect of this setup you'd like me to explain in more detail?

--- a/diagnostic-converter.js
+++ b/diagnostic-converter.js
@@ -1,0 +1,283 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import istanbulLibCoverage from "istanbul-lib-coverage";
+const { createCoverageMap } = istanbulLibCoverage;
+
+// Get the directory name in ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Function to convert Playwright coverage format to Istanbul format
+function convertToIstanbulFormat(playwrightCoverage) {
+  const coverageMap = createCoverageMap({});
+
+  // Project root directory
+  const projectRoot = __dirname;
+  console.log(`\n📁 Project root: ${projectRoot}`);
+  console.log(`📁 Source directory: ${path.join(projectRoot, "src")}`);
+
+  // List all source files to help with debugging
+  console.log("\n🔍 Source files in your project:");
+  try {
+    const srcDir = path.join(projectRoot, "src");
+    if (fs.existsSync(srcDir)) {
+      listFilesRecursively(srcDir);
+    } else {
+      console.log(`❌ src directory not found at ${srcDir}`);
+    }
+  } catch (error) {
+    console.error("Error listing source files:", error.message);
+  }
+
+  console.log("\n📊 Processing coverage entries:");
+  playwrightCoverage.forEach((entry, index) => {
+    console.log(`\n➡️ Entry #${index + 1}:`);
+    console.log(`   URL: ${entry.url}`);
+
+    // Extract the file path from the URL
+    let rawPath = entry.url;
+    let resolvedPath = "";
+
+    console.log(`   Processing path: ${rawPath}`);
+
+    if (rawPath.startsWith("file://")) {
+      // For file:// URLs, extract the path
+      rawPath = decodeURIComponent(rawPath.replace(/^file:\/\//, ""));
+      console.log(`   Decoded file:// path: ${rawPath}`);
+    } else if (rawPath.startsWith("http")) {
+      // For http URLs, extract the path portion
+      const urlPath = new URL(rawPath).pathname;
+      rawPath = urlPath === "/" ? "index.js" : urlPath;
+      console.log(`   Extracted HTTP path: ${rawPath}`);
+    }
+
+    // Try multiple path resolution strategies
+    const pathOptions = [
+      // Strategy 1: Use raw path as is
+      rawPath,
+
+      // Strategy 2: If path starts with /src, append to project root
+      rawPath.startsWith("/src") ? path.join(projectRoot, rawPath) : null,
+
+      // Strategy 3: If path starts with /src, remove the leading / and append to project root
+      rawPath.startsWith("/src")
+        ? path.join(projectRoot, rawPath.substring(1))
+        : null,
+
+      // Strategy 4: Try to use just the base file name in the src directory
+      path.join(projectRoot, "src", path.basename(rawPath)),
+
+      // Strategy 5: If it ends with .vue, try to find it in components dir
+      rawPath.endsWith(".vue")
+        ? path.join(projectRoot, "src", "components", path.basename(rawPath))
+        : null,
+    ].filter(Boolean); // Remove null entries
+
+    // Try each path strategy
+    let fileFound = false;
+    for (const potentialPath of pathOptions) {
+      console.log(`   Trying path: ${potentialPath}`);
+
+      if (fs.existsSync(potentialPath)) {
+        console.log(`   ✅ File found at: ${potentialPath}`);
+        resolvedPath = potentialPath;
+        fileFound = true;
+        break;
+      }
+    }
+
+    if (!fileFound) {
+      console.log("   ❌ File not found with any path strategy");
+      return; // Skip this entry
+    }
+
+    // Skip node_modules, test files and non-source files
+    if (
+      resolvedPath.includes("node_modules") ||
+      resolvedPath.includes("test") ||
+      resolvedPath.includes("tests") ||
+      (!resolvedPath.endsWith(".js") &&
+        !resolvedPath.endsWith(".ts") &&
+        !resolvedPath.endsWith(".vue"))
+    ) {
+      console.log(
+        "   ⏭️ Skipping file (node_modules, test, or non-source file)",
+      );
+      return;
+    }
+
+    console.log(`   💼 Creating coverage data for: ${resolvedPath}`);
+    console.log(`   Functions: ${entry.functions.length}`);
+
+    const fnMap = {};
+    const branchMap = {};
+    const statementMap = {};
+    const fnCovered = {};
+    const branchCovered = {};
+    const statementCovered = {};
+
+    let statementId = 0;
+    let coveredFunctions = 0;
+
+    // Map functions to statements and function coverage
+    entry.functions.forEach((fn, fnId) => {
+      // Create function mapping
+      fnMap[fnId] = {
+        name: fn.functionName || `(anonymous_${fnId})`,
+        decl: {
+          start: {
+            line: fn.ranges[0].startLine,
+            column: fn.ranges[0].startColumn,
+          },
+          end: { line: fn.ranges[0].endLine, column: fn.ranges[0].endColumn },
+        },
+        loc: {
+          start: {
+            line: fn.ranges[0].startLine,
+            column: fn.ranges[0].startColumn,
+          },
+          end: { line: fn.ranges[0].endLine, column: fn.ranges[0].endColumn },
+        },
+      };
+
+      // Set function coverage
+      const isCovered = fn.count > 0;
+      fnCovered[fnId] = isCovered ? 1 : 0;
+      if (isCovered) coveredFunctions++;
+
+      // Map function ranges to statements
+      fn.ranges.forEach((range) => {
+        statementMap[statementId] = {
+          start: { line: range.startLine, column: range.startColumn },
+          end: { line: range.endLine, column: range.endColumn },
+        };
+        statementCovered[statementId] = fn.count > 0 ? 1 : 0;
+        statementId++;
+      });
+    });
+
+    console.log(
+      `   📊 Covered functions: ${coveredFunctions}/${entry.functions.length}`,
+    );
+    console.log(`   📊 Total statements mapped: ${statementId}`);
+
+    // Create coverage data structure
+    const fileCoverage = {
+      path: resolvedPath,
+      statementMap,
+      fnMap,
+      branchMap,
+      s: statementCovered,
+      f: fnCovered,
+      b: branchCovered,
+    };
+
+    // Add this file's coverage to the map
+    coverageMap.addFileCoverage(fileCoverage);
+    console.log("   ✅ Coverage data added to map");
+  });
+
+  return coverageMap;
+}
+
+// Helper function to list all files in a directory recursively
+function listFilesRecursively(dir, depth = 0, maxDepth = 3) {
+  if (depth > maxDepth) return;
+
+  const indent = "  ".repeat(depth);
+  const files = fs.readdirSync(dir);
+
+  files.forEach((file) => {
+    const filePath = path.join(dir, file);
+    const stats = fs.statSync(filePath);
+
+    if (stats.isDirectory()) {
+      console.log(`${indent}📁 ${file}/`);
+      listFilesRecursively(filePath, depth + 1, maxDepth);
+    } else if (
+      file.endsWith(".vue") ||
+      file.endsWith(".js") ||
+      file.endsWith(".ts")
+    ) {
+      console.log(`${indent}📄 ${file}`);
+    }
+  });
+}
+
+// Main function to process the coverage file
+async function convertCoverage() {
+  try {
+    console.log("🔍 Starting diagnostic coverage conversion");
+
+    // Read the Playwright coverage file
+    const playwrightCoveragePath = path.join(
+      __dirname,
+      "playwright-coverage",
+      "coverage-data.json",
+    );
+
+    if (!fs.existsSync(playwrightCoveragePath)) {
+      console.error(`❌ Coverage file not found at: ${playwrightCoveragePath}`);
+      return;
+    }
+
+    console.log(`✅ Found coverage file at: ${playwrightCoveragePath}`);
+    const rawData = fs.readFileSync(playwrightCoveragePath, "utf8");
+    console.log(
+      `📊 Coverage file size: ${(rawData.length / 1024).toFixed(2)} KB`,
+    );
+
+    const playwrightCoverage = JSON.parse(rawData);
+    console.log(`📊 Found ${playwrightCoverage.length} coverage entries`);
+
+    // Convert to Istanbul format
+    console.log("\n🔄 Converting to Istanbul format...");
+    const istanbulCoverage = convertToIstanbulFormat(playwrightCoverage);
+
+    // Create output directory
+    const nycOutputDir = path.join(__dirname, ".nyc_output");
+    if (!fs.existsSync(nycOutputDir)) {
+      fs.mkdirSync(nycOutputDir, { recursive: true });
+      console.log(`📁 Created directory: ${nycOutputDir}`);
+    }
+
+    // Write Istanbul-formatted coverage
+    const outputPath = path.join(nycOutputDir, "out.json");
+
+    const coverageData = istanbulCoverage.toJSON();
+    console.log(
+      `\n📊 Final coverage data contains ${Object.keys(coverageData).length} files`,
+    );
+
+    // Check if we have any actual coverage data
+    if (Object.keys(coverageData).length === 0) {
+      console.log(
+        "⚠️ WARNING: No files were successfully mapped for coverage!",
+      );
+    } else {
+      // List the files that were successfully mapped
+      console.log("\n✅ Files with coverage data:");
+      Object.keys(coverageData).forEach((file) => {
+        console.log(`   - ${file}`);
+      });
+    }
+
+    fs.writeFileSync(outputPath, JSON.stringify(coverageData), "utf8");
+    console.log(`\n✅ Converted coverage data written to ${outputPath}`);
+
+    // Display next steps
+    console.log("\n📋 Next steps:");
+    console.log("1. Run: npx nyc report");
+    console.log("2. Check the coverage report in the coverage/ directory");
+    console.log(
+      "3. If issues persist, use the debug information above to adjust path mapping",
+    );
+  } catch (error) {
+    console.error("❌ Error converting coverage:", error);
+    console.error(error.stack);
+  }
+}
+
+// Execute the main function
+convertCoverage();

--- a/tests/explicit-coverage.spec.ts
+++ b/tests/explicit-coverage.spec.ts
@@ -1,0 +1,86 @@
+// File: /Users/shantirai/Desktop/PROJECTS/avatarGenImg/tests/explicit-coverage.spec.ts
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+test("Collect coverage explicitly", async ({ page }) => {
+  // Start JS coverage collection with resetOnNavigation: false to keep coverage across navigations
+  console.log("Starting JS coverage collection...");
+  await page.coverage.startJSCoverage({
+    resetOnNavigation: false,
+    // Include all JavaScript, not just from our origin
+    includeRawScriptCoverage: true,
+  });
+
+  // Navigate to your application
+  await page.goto("/", { waitUntil: "networkidle" });
+  console.log("Page loaded, starting interactions...");
+
+  // Make sure we wait for the application to be fully ready
+  // This is important for Vue applications that may have a mounting delay
+  await page.waitForSelector('h1:has-text("Who You Were Meant To Be")');
+
+  // Get the text input by its placeholder text (more reliable than by type)
+  const inputLocator = page.getByRole("textbox", {
+    name: /Create your alter ego/i,
+  });
+
+  // Wait for input to be visible and interactable
+  await inputLocator.waitFor({ state: "visible" });
+
+  // Test that input is working by typing text
+  await inputLocator.fill("A futuristic robot with glowing blue eyes");
+
+  // Verify the input value was set correctly (this ensures interaction worked)
+  const inputValue = await inputLocator.inputValue();
+  expect(inputValue).toBe("A futuristic robot with glowing blue eyes");
+
+  // Get the generate button and click it
+  const generateButton = page.getByRole("button", {
+    name: "Create Your Legend",
+  });
+  await generateButton.waitFor({ state: "visible" });
+  await generateButton.click();
+
+  // Wait for some visual indication that generation is happening or completed
+  // You might need to adjust this based on your application's behavior
+  // For example, waiting for a loading indicator to appear and disappear
+  await page.waitForTimeout(2000); // Give enough time for the app to process
+
+  // Try additional interactions to increase coverage
+  await inputLocator.clear();
+  await inputLocator.fill("A wizard with a flowing purple cloak");
+  await generateButton.click();
+
+  // Wait for processing
+  await page.waitForTimeout(2000);
+
+  // Force-trigger any event handlers that might be registered
+  // This can help execute code paths that might not be covered otherwise
+  await page.evaluate(() => {
+    // Trigger window resize event (often has handlers)
+    window.dispatchEvent(new Event("resize"));
+
+    // If your app uses custom events, trigger those here
+    // For example: document.dispatchEvent(new CustomEvent('app:someEvent'));
+  });
+
+  console.log("Interactions complete, collecting coverage...");
+
+  // Stop coverage collection
+  const coverage = await page.coverage.stopJSCoverage();
+
+  console.log(`Collected coverage data: ${coverage.length} entries`);
+
+  // Create directory for coverage data if it doesn't exist
+  const coverageDir = path.join(process.cwd(), "playwright-coverage");
+  if (!fs.existsSync(coverageDir)) {
+    fs.mkdirSync(coverageDir, { recursive: true });
+    console.log(`Created directory: ${coverageDir}`);
+  }
+
+  // Save raw coverage data
+  const filePath = path.join(coverageDir, "coverage-data.json");
+  fs.writeFileSync(filePath, JSON.stringify(coverage, null, 2), "utf8");
+  console.log(`Saved coverage data to: ${filePath}`);
+});


### PR DESCRIPTION
- Add explicit JS coverage collection in Playwright tests
- Create coverage conversion pipeline from V8 to Istanbul format
- Set up nyc reporting for HTML/LCOV/text reports
- Fix timeout issues in test selectors using role-based locators
- Improve test reliability with proper waiting strategies

NOTE: Coverage reporting pipeline functional but currently shows 0%. Further improvements needed to properly exercise component code.